### PR TITLE
Fix for #3 - Spaces and other chars in routes

### DIFF
--- a/lib/satnav.js
+++ b/lib/satnav.js
@@ -78,7 +78,7 @@
 		path = '^' + path;
 		path = path.replace(/(\?)?\{([^}]+)\}/g, function(match, optional, param) {
 			params.push({ name : param, optional : (typeof optional !== 'undefined') ? true : false });
-			return '([\\w-.]+)?';
+			return '([^{}\\/]+)?';
 		}).replace(/\//g, '\\/?');
 		path += '\\/?$';
 		_routes.push({ regex : new RegExp(path), params : params, directions : directions });


### PR DESCRIPTION
This should resolve #3.  Basically switch Regular Expression over to use negative search for anything but {} and /.
